### PR TITLE
Raise error when GEF is GEF-BOREHOLE-Report and not GEF-BORE-Report

### DIFF
--- a/pygef/gef.py
+++ b/pygef/gef.py
@@ -121,6 +121,9 @@ class ParseGEF:
             parsed = ParseCPT(header_s, data_s, self.zid)
         elif self.type == "bore":
             parsed = ParseBORE(header_s, data_s)
+        elif self.type == "borehole-report":
+            raise ValueError("Selected gef file is a GEF-BOREHOLE-Report. Can only parse "
+                             "GEF-CPT-Report and GEF-BORE-Report. Check the PROCEDURECODE.")
         else:
             raise ValueError("The selected gef file is not a cpt nor a borehole. "
                              "Check the REPORTCODE or the PROCEDURECODE.")

--- a/pygef/utils.py
+++ b/pygef/utils.py
@@ -135,8 +135,10 @@ def parse_gef_type(s):
 
     if "cpt" in proc_code or "dis" in proc_code:
         gef_type = "cpt"
-    elif "bore" in proc_code:
+    elif "bore" in proc_code and not "borehole" in proc_code:
         gef_type = "bore"
+    elif "borehole" in proc_code:
+        gef_type = "borehole-report"
     else:
         gef_type = None
 


### PR DESCRIPTION
Make distinction between GEF-BORE-Report (ParseGEF readable) and GEF-BOREHOLE-Report (not readable)