### PR TITLE
if friction_number ratio is in cpt that is considered as friction_number

### DIFF
--- a/pygef/gef.py
+++ b/pygef/gef.py
@@ -422,6 +422,8 @@ class ParseCPT:
 
     @staticmethod
     def calculate_friction_number(df):
+        if "friction_number" in df.columns:
+            return df
         if "fs" in df.columns and "qc" in df.columns:
             df = df.assign(friction_number=(df["fs"].values / df["qc"].values * 100))
         if "friction_number" not in df.columns:


### PR DESCRIPTION
recent discovery: the companies that make the cpts sometimes alter the friction ratio, so it is not always equal to fs/qc *100. When the friction ratio is in the cpt, that should be considered as the correct one.