### PR TITLE
Fix

### DIFF
--- a/pygef/gef.py
+++ b/pygef/gef.py
@@ -584,11 +584,11 @@ class ParseCPT:
 
         self.df = (
             self.parse_data(header_s, data_s)
+            .pipe(self.replace_column_void, self.column_void)
             .pipe(self.correct_pre_excavated_depth, self.pre_excavated_depth)
             .pipe(self.correct_depth_with_inclination)
             .pipe(lambda df: df.assign(depth=np.abs(df["depth"].values)))
             .pipe(self.calculate_elevation_with_respect_to_nap, zid, height_system)
-            .pipe(self.replace_column_void, self.column_void)
             .pipe(self.calculate_friction_number)
         )
 
@@ -620,7 +620,7 @@ class ParseCPT:
             return df.rename(columns={"corrected_depth": "depth"})
         if "inclination" in df.columns:
             diff_t_depth = np.diff(df["penetration_length"].values) * np.cos(
-                np.radians(df["inclination"].values[:-1])
+                np.radians(df["inclination"].fillna(0).values[:-1])
             )
             # corrected depth
             return df.assign(

--- a/pygef/tests.py
+++ b/pygef/tests.py
@@ -459,6 +459,46 @@ class GefTest(unittest.TestCase):
         )
         assert_frame_equal(df_calculated, df)
 
+    def test_parse_pre_excavated_dept_with_void_inclination(self):
+        cpt = ParseGEF(string="""
+            #COLUMN= 6
+            #COLUMNINFO= 1, m, Sondeerlengte, 1
+            #COLUMNINFO= 2, MPa, Conuswaarde, 2
+            #COLUMNINFO= 3, MPa, Wrijvingsweerstand, 3
+            #COLUMNINFO= 4, Deg, Helling, 8
+            #COLUMNINFO= 5, %, Wrijvingsgetal, 4
+            #COLUMNINFO= 6, MPa, Waterspanning, 5
+            #COLUMNVOID= 2, -9999.000000
+            #COLUMNVOID= 3, -9999.000000
+            #COLUMNVOID= 4, -9999.000000
+            #COLUMNVOID= 5, -9999.000000
+            #COLUMNVOID= 6, -9999.000000
+            #LASTSCAN= 3
+            #ZID= 31000, -0.39, 0.05
+            #MEASUREMENTVAR= 13, 1.500000, m, voorgeboorde/voorgegraven diepte
+            #REPORTCODE= GEF-CPT-Report, 1, 1, 0, -
+            #EOH=
+            0.0000e+000 -9.9990e+003 -9.9990e+003 -9.9990e+003 -9.9990e+003 -9.9990e+003 
+            1.5100e+000 9.1800e+000 5.3238e-002 5.8398e-001 5.7314e-001 3.0107e-003 
+            1.5300e+000 9.3044e+000 5.3803e-002 8.2007e-001 5.7986e-001 3.3362e-003 
+        """)   
+        actual = cpt.df.round(6)
+
+        expected = pd.DataFrame(
+            {
+                "penetration_length": [1.51, 1.53],
+                "qc": [9.1800, 9.3044],
+                "fs": [0.053238, 0.053803],
+                "inclination": [0.58398, 0.82007],
+                "friction_number": [0.579935, 0.578253],
+                "u1": [0.003011, 0.003336],
+                "depth": [1.510000, 1.529999],
+                "elevation_with_respect_to_NAP": [-1.90, -1.919999],
+            }
+        )
+        assert_frame_equal(actual, expected)
+
+
     def test_delta_depth(self):
         df1 = pd.DataFrame({"depth": [0, 0.5, 1]})
         v = geo.delta_depth(df1)

--- a/pygef/tests.py
+++ b/pygef/tests.py
@@ -460,28 +460,30 @@ class GefTest(unittest.TestCase):
         assert_frame_equal(df_calculated, df)
 
     def test_parse_pre_excavated_dept_with_void_inclination(self):
-        cpt = ParseGEF(string="""
-            #COLUMN= 6
-            #COLUMNINFO= 1, m, Sondeerlengte, 1
-            #COLUMNINFO= 2, MPa, Conuswaarde, 2
-            #COLUMNINFO= 3, MPa, Wrijvingsweerstand, 3
-            #COLUMNINFO= 4, Deg, Helling, 8
-            #COLUMNINFO= 5, %, Wrijvingsgetal, 4
-            #COLUMNINFO= 6, MPa, Waterspanning, 5
-            #COLUMNVOID= 2, -9999.000000
-            #COLUMNVOID= 3, -9999.000000
-            #COLUMNVOID= 4, -9999.000000
-            #COLUMNVOID= 5, -9999.000000
-            #COLUMNVOID= 6, -9999.000000
-            #LASTSCAN= 3
-            #ZID= 31000, -0.39, 0.05
-            #MEASUREMENTVAR= 13, 1.500000, m, voorgeboorde/voorgegraven diepte
-            #REPORTCODE= GEF-CPT-Report, 1, 1, 0, -
-            #EOH=
-            0.0000e+000 -9.9990e+003 -9.9990e+003 -9.9990e+003 -9.9990e+003 -9.9990e+003 
-            1.5100e+000 9.1800e+000 5.3238e-002 5.8398e-001 5.7314e-001 3.0107e-003 
-            1.5300e+000 9.3044e+000 5.3803e-002 8.2007e-001 5.7986e-001 3.3362e-003 
-        """)   
+        cpt = ParseGEF(
+            string="""
+                #COLUMN= 6
+                #COLUMNINFO= 1, m, Sondeerlengte, 1
+                #COLUMNINFO= 2, MPa, Conuswaarde, 2
+                #COLUMNINFO= 3, MPa, Wrijvingsweerstand, 3
+                #COLUMNINFO= 4, Deg, Helling, 8
+                #COLUMNINFO= 5, %, Wrijvingsgetal, 4
+                #COLUMNINFO= 6, MPa, Waterspanning, 5
+                #COLUMNVOID= 2, -9999.000000
+                #COLUMNVOID= 3, -9999.000000
+                #COLUMNVOID= 4, -9999.000000
+                #COLUMNVOID= 5, -9999.000000
+                #COLUMNVOID= 6, -9999.000000
+                #LASTSCAN= 3
+                #ZID= 31000, -0.39, 0.05
+                #MEASUREMENTVAR= 13, 1.500000, m, voorgeboorde/voorgegraven diepte
+                #REPORTCODE= GEF-CPT-Report, 1, 1, 0, -
+                #EOH=
+                0.0000e+000 -9.9990e+003 -9.9990e+003 -9.9990e+003 -9.9990e+003 -9.9990e+003 
+                1.5100e+000 9.1800e+000 5.3238e-002 5.8398e-001 5.7314e-001 3.0107e-003 
+                1.5300e+000 9.3044e+000 5.3803e-002 8.2007e-001 5.7986e-001 3.3362e-003 
+            """
+        )
         actual = cpt.df.round(6)
 
         expected = pd.DataFrame(
@@ -497,7 +499,6 @@ class GefTest(unittest.TestCase):
             }
         )
         assert_frame_equal(actual, expected)
-
 
     def test_delta_depth(self):
         df1 = pd.DataFrame({"depth": [0, 0.5, 1]})


### PR DESCRIPTION
- Reordered parsing for GEF.
- Replacing NaN values with 0 in correction for inclination.

This way, column voids are handled before the data is used (which is safer). Accordingly, issues that arrise from the NaN values being used can be dealt with. Which is the case for values in the inclination in the function `correct_depth_with_inclination`, which has been dealt with  by temporarily replacing NaN values by zero before they are used.

This fix resolves issue [issue #57 ](https://github.com/ritchie46/pygef/issues/57).