### PR TITLE
Parsing full test IDs that contain spaces

### DIFF
--- a/pygef/tests.py
+++ b/pygef/tests.py
@@ -98,6 +98,27 @@ class GefTest(unittest.TestCase):
         v = utils.parse_cone_id(s)
         self.assertEqual("S15CFII.d82", v)
 
+    def test_parse_test_id(self):
+        # Test ID without spaces on a single line
+        s = "#TESTID= CPT-01"
+        v = utils.parse_test_id(s)
+        self.assertEqual("CPT-01", v)
+
+        # Test ID without spaces on a single line and trailing white space
+        s = "#TESTID= CPT-02   "
+        v = utils.parse_test_id(s)
+        self.assertEqual("CPT-02", v)
+
+        # Test ID with a space on a single line
+        s = "#TESTID= CPT 03"
+        v = utils.parse_test_id(s)
+        self.assertEqual("CPT 03", v)
+
+        # Test ID with a space and trailing whitespace
+        s = "#TESTID= CPT 03   "
+        v = utils.parse_test_id(s)
+        self.assertEqual("CPT 03", v)
+
     def test_parse_gef_type(self):
         s = r"#PROCEDURECODE= GEF-CPT-Report"
         v = utils.parse_gef_type(s)

--- a/pygef/utils.py
+++ b/pygef/utils.py
@@ -296,7 +296,10 @@ def parse_test_id(s):
     :param s: (str) String to search for regex pattern.
     :return: test id.
     """
-    return parse_regex_cast(r"#TESTID+[=\s+]+(.+?)\s+(\S+)", s, str, 1)
+    result = parse_regex_cast(r"#TESTID+[=\s+]+(.*)", s, str, 1)
+    if result != None:
+        result = result.strip()
+    return result
 
 
 def parse_record_separator(s):


### PR DESCRIPTION
updated parse_test_id() such that it can parse Test IDs that contain spaces. This pull request is a suggested fix for issue #63.

I am not too familiar with regex expressions, but this is how I have gotten it to work. If there exists a solution that does not use the `.strip()` call, which passes the tests, then I guess that would be the preferred solution.